### PR TITLE
Do not modify frozen string in postgres-upgrade-database.rb

### DIFF
--- a/cmd/postgresql-upgrade-database.rb
+++ b/cmd/postgresql-upgrade-database.rb
@@ -104,7 +104,7 @@ module Homebrew
         initdb_args += if setting == "server_encoding"
           ["-E #{value}"]
         else
-          ["--#{setting.tr!("_", "-")}=#{value}"]
+          ["--#{setting.tr("_", "-")}=#{value}"]
         end
       end
 


### PR DESCRIPTION
Currently this script does not work with actually frozen string literals because of `tr!` call


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
